### PR TITLE
#ERP-144: Module installer Source Directory parameter implementation …

### DIFF
--- a/src/Installer/AbstractInstaller.php
+++ b/src/Installer/AbstractInstaller.php
@@ -34,6 +34,9 @@ abstract class AbstractInstaller
 {
     const EXTRA_PARAMETER_KEY_ROOT = 'oxideshop';
 
+    /** Used to determine third party package internal source path. */
+    const EXTRA_PARAMETER_KEY_SOURCE = 'source-directory';
+
     /** Used to install third party integrations. */
     const EXTRA_PARAMETER_KEY_TARGET = 'target-directory';
 

--- a/src/Installer/ModuleInstaller.php
+++ b/src/Installer/ModuleInstaller.php
@@ -50,7 +50,7 @@ class ModuleInstaller extends AbstractInstaller
         $this->getIO()->write("Installing {$package->getName()} package");
         
         $fileSystem = $this->getFileSystem();
-        $fileSystem->mirror($packagePath, $this->formTargetPath());
+        $fileSystem->mirror($this->formSourcePath($packagePath), $this->formTargetPath());
     }
 
     /**
@@ -60,6 +60,25 @@ class ModuleInstaller extends AbstractInstaller
      */
     public function update($packagePath)
     {
+    }
+
+    /**
+     * If module source directory option provided add it's relative path.
+     * Otherwise return plain package path.
+     *
+     * @param string $packagePath
+     *
+     * @return string
+     */
+    protected function formSourcePath($packagePath)
+    {
+        $sourceDirectory = $this->getExtraParameterValueByKey(static::EXTRA_PARAMETER_KEY_SOURCE);
+
+        if (empty($sourceDirectory)) {
+            return $packagePath;
+        }
+
+        return $packagePath . "/$sourceDirectory";
     }
 
     /**

--- a/tests/Integration/Installer/ModuleInstallerTest.php
+++ b/tests/Integration/Installer/ModuleInstallerTest.php
@@ -94,6 +94,33 @@ class ModuleInstallerTest extends \PHPUnit_Framework_TestCase
         $this->assertFileExists($installedModuleMetadata);
     }
 
+    public function testCheckIfModuleIsInstalledFromProvidedSourceDirectory()
+    {
+        $structure = [
+            'vendor/oxid-esales/erp/copy_this/modules/erp' => [
+                'metadata.php' => '<?php',
+            ]
+        ];
+        vfsStream::setup('root', 777, ['projectRoot' => $this->getStructurePreparator()->prepareStructure($structure)]);
+
+        $rootPath = vfsStream::url('root/projectRoot');
+        $eshopRootPath = "$rootPath/source";
+        $installedModuleMetadata = "$eshopRootPath/modules/erp/metadata.php";
+
+        $package = new Package('oxid-esales/erp', 'dev', 'dev');
+        $shopPreparator = new ModuleInstaller(new Filesystem(), new NullIO(), $eshopRootPath, $package);
+        $package->setExtra(
+            [ModuleInstaller::EXTRA_PARAMETER_KEY_ROOT => [
+                ModuleInstaller::EXTRA_PARAMETER_KEY_SOURCE => 'copy_this/modules/erp',
+                ModuleInstaller::EXTRA_PARAMETER_KEY_TARGET => 'erp',
+            ]]
+        );
+        $moduleInVendor = "$rootPath/vendor/oxid-esales/erp";
+        $shopPreparator->install($moduleInVendor);
+
+        $this->assertFileExists($installedModuleMetadata);
+    }
+
     /**
      * @return StructurePreparator
      */


### PR DESCRIPTION
Extended OXID Composer Plugin with "source-directory" option and applied it in modules installer.
It allows to install module from provided location inside it's original repository, e.g. "copy_this/modules/my_module". 

Added additional test to cover this case.

This feature provide much better flexibility for module vendors - no restructuring of original repositories is needed!