### PR TITLE
Prevent folders from being copied onto themselves and being broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
   - composer install
 
 script:
-  - vendor/bin/phpunit tests
+  - vendor/bin/phpunit -c tests/phpunit.xml tests

--- a/tests/Unit/Utilities/CopyFileManager/CopyGlobFilteredFileManagerTest.php
+++ b/tests/Unit/Utilities/CopyFileManager/CopyGlobFilteredFileManagerTest.php
@@ -46,6 +46,20 @@ class CopyGlobFilteredFileManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertFilesNotExistInDestination(['module.php']);
     }
 
+    public function testNoExceptionThrownWhenDestionationFileDoesNotExist()
+    {
+        $inputFiles = [
+            "a/module.php" => "PHP_1",
+        ];
+
+        $this->prepareVirtualFileSystem($inputFiles, []);
+
+        $this->simulateCopyWithFilter('a/module.php', 'b/module.php');
+
+        $this->assertFilesExistInDestination(['b/module.php']);
+        $this->assertFileEquals($this->getSourcePath('a/module.php'), $this->getDestinationPath('b/module.php'));
+    }
+
     public function testThrowsExceptionWhenSourceValueIsInvalid()
     {
         $inputFiles = [
@@ -62,6 +76,22 @@ class CopyGlobFilteredFileManagerTest extends \PHPUnit_Framework_TestCase
 
         $destinationPath = $this->getSourcePath('module.php');
         CopyGlobFilteredFileManager::copy(1, $destinationPath);
+    }
+
+    public function testNoExceptionThrownWhenSourceAndDestinationAreIdentical()
+    {
+        $inputFiles = [
+            "module.php" => "PHP_1",
+            "module_backup.php" => "PHP_1",
+        ];
+
+        $this->prepareVirtualFileSystem($inputFiles, []);
+
+        $this->simulateCopyWithFilter('module.php', '../src/module.php');
+
+        $this->assertFilesExistInSource(['module.php']);
+        $this->assertFilesNotExistInDestination(['module.php']);
+        $this->assertFileEquals($this->getSourcePath('module.php'), $this->getSourcePath('module_backup.php'));
     }
 
     public function testThrowsExceptionWhenDestinationValueIsInvalid()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,4 +4,6 @@
  * See LICENSE file for license details.
  */
 
+define('OXID_PHP_UNIT', true);
+
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,2 @@
+<phpunit bootstrap="./bootstrap.php">
+</phpunit>


### PR DESCRIPTION
Developing an OXID module with metadata version 2.0 in-place (inside the source/module folder) is currently not possible because:

- metadata version 2.0 requires class autoloading (which is good!)
- class autoloading requires the module to be "installed with" or "known to" Composer
- any installing of an OXID module with composer triggers the copying of module files according to the "extra" -> "oxideshop" section of the module's composer.json
- if the module being developed is located in modules/vendor/module-id, then the Composer plugin will copy the module onto itself, which causes all files to become zero-length

Note that a possible workaround is to specifiy a non-existent folder in "source-directory", but this has to be actively added to the composer.json. The default configuration causes the module folder to be overwritten with zero-length files.

The fix proposed here adds a check in CopyGlobFilteredFileManager::copy() which silently aborts the copy if the source and destination paths are identical. This is done using realpath() because due to Composer's symlinking of all folders into the vendor/ directory, the Path library can't be used alone.

Tests are included. The realpath() calls are stubbed during tests, as vfsStream does not support it.