### PR TITLE
fixed filter for setup files

### DIFF
--- a/src/Installer/Package/ShopPackageInstaller.php
+++ b/src/Installer/Package/ShopPackageInstaller.php
@@ -22,7 +22,7 @@ class ShopPackageInstaller extends AbstractPackageInstaller
     const SHOP_SOURCE_SETUP_DIRECTORY = 'Setup';
     const HTACCESS_FILTER = '**/.htaccess';
     const ROBOTS_EXCLUSION_FILTER = '**/robots.txt';
-    const SETUP_FILES_FILTER = self::SHOP_SOURCE_SETUP_DIRECTORY . AbstractPackageInstaller::BLACKLIST_ALL_FILES;
+    const SETUP_FILES_FILTER = self::SHOP_SOURCE_SETUP_DIRECTORY . DIRECTORY_SEPARATOR . AbstractPackageInstaller::BLACKLIST_ALL_FILES;
 
     /**
      * @return bool


### PR DESCRIPTION
Bugfix: The Setup directory has always been copied to "source"