### PR TITLE
install root packages from the current working directory

### DIFF
--- a/src/Installer/PackageInstallerTrigger.php
+++ b/src/Installer/PackageInstallerTrigger.php
@@ -8,6 +8,7 @@ namespace OxidEsales\ComposerPlugin\Installer;
 
 use Composer\Installer\LibraryInstaller;
 use Composer\Package\PackageInterface;
+use Composer\Package\RootPackage;
 use OxidEsales\ComposerPlugin\Installer\Package\AbstractPackageInstaller;
 use OxidEsales\ComposerPlugin\Installer\Package\ComponentInstaller;
 use OxidEsales\ComposerPlugin\Installer\Package\ShopPackageInstaller;
@@ -56,6 +57,14 @@ class PackageInstallerTrigger extends LibraryInstaller
     public function setSettings($settings)
     {
         $this->settings = $settings;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getInstallPath(PackageInterface $package)
+    {
+        return $package instanceof RootPackage ? getcwd() : parent::getInstallPath($package);
     }
 
     /**

--- a/src/Installer/PackageInstallerTrigger.php
+++ b/src/Installer/PackageInstallerTrigger.php
@@ -8,7 +8,7 @@ namespace OxidEsales\ComposerPlugin\Installer;
 
 use Composer\Installer\LibraryInstaller;
 use Composer\Package\PackageInterface;
-use Composer\Package\RootPackage;
+use Composer\Package\RootPackageInterface;
 use OxidEsales\ComposerPlugin\Installer\Package\AbstractPackageInstaller;
 use OxidEsales\ComposerPlugin\Installer\Package\ComponentInstaller;
 use OxidEsales\ComposerPlugin\Installer\Package\ShopPackageInstaller;
@@ -64,7 +64,7 @@ class PackageInstallerTrigger extends LibraryInstaller
      */
     public function getInstallPath(PackageInterface $package)
     {
-        return $package instanceof RootPackage ? getcwd() : parent::getInstallPath($package);
+        return $package instanceof RootPackageInterface ? getcwd() : parent::getInstallPath($package);
     }
 
     /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -88,7 +88,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         $repo = $this->composer->getRepositoryManager()->getLocalRepository();
 
-        foreach ($repo->getPackages() as $package) {
+        foreach (array_merge($repo->getPackages(), [$this->composer->getPackage()]) as $package) {
             if ($this->packageInstallerTrigger->supports($package->getType())) {
                 if ($actionName === static::ACTION_INSTALL) {
                     $this->packageInstallerTrigger->installPackage($package);

--- a/tests/Integration/Installer/PackageInstallerTriggerTest.php
+++ b/tests/Integration/Installer/PackageInstallerTriggerTest.php
@@ -9,6 +9,9 @@ namespace OxidEsales\ComposerPlugin\Tests\Integration\Installer;
 use Composer\Composer;
 use Composer\Config;
 use Composer\IO\NullIO;
+use Composer\Package\Package;
+use Composer\Package\RootPackage;
+use Composer\Util\Filesystem;
 use OxidEsales\ComposerPlugin\Installer\PackageInstallerTrigger;
 
 class PackageInstallerTriggerTest extends \PHPUnit\Framework\TestCase
@@ -42,5 +45,30 @@ class PackageInstallerTriggerTest extends \PHPUnit\Framework\TestCase
         $result = $packageInstallerStub->getShopSourcePath();
 
         $this->assertEquals($result, getcwd() . '/source');
+    }
+
+    /**
+     * @covers PackageInstallerTrigger::getInstallPath
+     */
+    public function testGetInstallPath()
+    {
+        $composer = new Composer;
+        $composer->setConfig(new Config);
+        $trigger = new PackageInstallerTrigger(
+            new NullIO,
+            $composer,
+            'library',
+            $this->getMockBuilder(Filesystem::class)->getMock()
+        );
+
+        $this->assertSame(
+            'foo/bar',
+            $trigger->getInstallPath(new Package('foo/bar', null, null))
+        );
+
+        $this->assertSame(
+            getcwd(),
+            $trigger->getInstallPath(new RootPackage('foo/bar', null, null))
+        );
     }
 }

--- a/tests/Integration/PluginTest.php
+++ b/tests/Integration/PluginTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+namespace OxidEsales\ComposerPlugin\Tests\Integration;
+
+use Composer\Composer;
+use Composer\Config;
+use Composer\Installer\InstallationManager;
+use Composer\IO\NullIO;
+use Composer\Package\Package;
+use Composer\Package\RootPackage;
+use Composer\Repository\RepositoryManager;
+use Composer\Repository\WritableArrayRepository;
+use OxidEsales\ComposerPlugin\Plugin;
+
+class PluginTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @covers Plugin::executeAction
+     */
+    public function testExecuteAction()
+    {
+        $composer = new Composer;
+        $composer->setConfig(new Config);
+        $composer->setInstallationManager(new InstallationManager);
+        $composer->setPackage($this->package(RootPackage::class));
+        $composer->setRepositoryManager($manager = new RepositoryManager(new NullIO, new Config));
+        $manager->setLocalRepository($repo = new WritableArrayRepository);
+        $repo->addPackage($this->package());
+        $plugin = new Plugin;
+        $plugin->activate($composer, new NullIO);
+        $plugin->installPackages();
+    }
+
+    /**
+     * @param string $class
+     *
+     * @return mixed
+     */
+    private function package($class = Package::class)
+    {
+        $mock =  $this->getMockBuilder($class)->disableOriginalConstructor()->getMock();
+        $mock->expects($this->once())->method('getType');
+        return $mock;
+    }
+}


### PR DESCRIPTION
When you develop a new module, you need a working shop environment.
The necessary packages can be defined in the `requie-dev` section.

```json
{
  "name": "foo/bar",
  "type": "oxideshop-module",
  "require": {
    "php": ">=7.1",
    ...
  },
  "require-dev": {
    "oxid-esales/oxideshop-ce": "^6",
    ...
  },
  "extra": {
    "oxideshop": {
      "blacklist-filter": [
        ".*/**/*",
        "config/**/*",
        "source/**/*",
        "src/**/*",
        "vendor/**/*",
        ...
      ],
      "target-directory": "foo/bar"
    }
  }
}
```

In order for your own module to be installed and recognized by the shop, the installer must handle the root packages.