### PR TITLE
implement whitelist filter

### DIFF
--- a/src/Installer/Package/AbstractPackageInstaller.php
+++ b/src/Installer/Package/AbstractPackageInstaller.php
@@ -32,6 +32,9 @@ abstract class AbstractPackageInstaller
     /** List of glob expressions used to blacklist files being copied. */
     const EXTRA_PARAMETER_FILTER_BLACKLIST = 'blacklist-filter';
 
+    /** List of glob expressions used to whitelist files being copied. */
+    const EXTRA_PARAMETER_FILTER_WHITELIST = 'whitelist-filter';
+
     /** Glob expression to filter all files, might be used to filter whole directory. */
     const BLACKLIST_ALL_FILES = '**/*';
 
@@ -108,6 +111,16 @@ abstract class AbstractPackageInstaller
     }
 
     /**
+     * Return the value defined in composer extra parameters for whitelist filtering.
+     *
+     * @return array
+     */
+    protected function getWhitelistFilterValue()
+    {
+        return $this->getExtraParameterValueByKey(static::EXTRA_PARAMETER_FILTER_WHITELIST, []);
+    }
+
+    /**
      * Search for parameter with specific key in "extra" composer configuration block
      *
      * @param string $extraParameterKey
@@ -119,9 +132,7 @@ abstract class AbstractPackageInstaller
     {
         $extraParameters = $this->getPackage()->getExtra();
 
-        $extraParameterValue = $extraParameters[static::EXTRA_PARAMETER_KEY_ROOT][$extraParameterKey] ?? null;
-
-        return (!empty($extraParameterValue)) ? $extraParameterValue : $defaultValue;
+        return $extraParameters[static::EXTRA_PARAMETER_KEY_ROOT][$extraParameterKey] ?? $defaultValue;
     }
 
     /**
@@ -140,23 +151,6 @@ abstract class AbstractPackageInstaller
     protected function getVCSFilter()
     {
         return [self::BLACKLIST_VCS_DIRECTORY_FILTER, self::BLACKLIST_VCS_IGNORE_FILE];
-    }
-
-    /**
-     * Combine multiple glob expression lists into one list
-     *
-     * @param array $listOfGlobExpressionLists E.g. [["*.txt", "*.pdf"], ["*.md"]]
-     *
-     * @return array
-     */
-    protected function getCombinedFilters($listOfGlobExpressionLists)
-    {
-        $filters = [];
-        foreach ($listOfGlobExpressionLists as $filter) {
-            $filters = array_merge($filters, $filter);
-        }
-
-        return $filters;
     }
 
     /**

--- a/src/Installer/Package/ModulePackageInstaller.php
+++ b/src/Installer/Package/ModulePackageInstaller.php
@@ -65,15 +65,18 @@ class ModulePackageInstaller extends AbstractPackageInstaller
      */
     protected function copyPackage($packagePath)
     {
-        $filtersToApply = [
-            $this->getBlacklistFilterValue(),
-            $this->getVCSFilter(),
-        ];
+        if (!($isWhiteList = $filter = $this->getWhitelistFilterValue())) {
+            $filter = array_merge(
+                $this->getBlacklistFilterValue(),
+                $this->getVCSFilter()
+            );
+        }
 
         CopyGlobFilteredFileManager::copy(
             $this->formSourcePath($packagePath),
             $this->formTargetPath(),
-            $this->getCombinedFilters($filtersToApply)
+            $filter,
+            (bool) $isWhiteList
         );
     }
 

--- a/src/Installer/Package/ShopPackageInstaller.php
+++ b/src/Installer/Package/ShopPackageInstaller.php
@@ -87,18 +87,19 @@ class ShopPackageInstaller extends AbstractPackageInstaller
      */
     private function copyShopSourceFromPackageToTarget($packagePath)
     {
-        $filtersToApply = [
-            $this->getBlacklistFilterValue(),
-            [self::HTACCESS_FILTER],
-            [self::ROBOTS_EXCLUSION_FILTER],
-            [self::SETUP_FILES_FILTER],
-            $this->getVCSFilter(),
-        ];
+        if (!($isWhiteList = $filter = $this->getWhitelistFilterValue())) {
+            $filter = array_merge(
+                $this->getBlacklistFilterValue(),
+                [self::HTACCESS_FILTER, self::ROBOTS_EXCLUSION_FILTER, self::SETUP_FILES_FILTER],
+                $this->getVCSFilter()
+            );
+        }
 
         CopyGlobFilteredFileManager::copy(
             $this->getPackageDirectoryOfShopSource($packagePath),
             $this->getTargetDirectoryOfShopSource(),
-            $this->getCombinedFilters($filtersToApply)
+            $filter,
+            (bool) $isWhiteList
         );
     }
 

--- a/src/Installer/Package/ThemePackageInstaller.php
+++ b/src/Installer/Package/ThemePackageInstaller.php
@@ -66,16 +66,19 @@ class ThemePackageInstaller extends AbstractPackageInstaller
      */
     protected function copyPackage($packagePath)
     {
-        $filtersToApply = [
-            [Path::join($this->formAssetsDirectoryName(), AbstractPackageInstaller::BLACKLIST_ALL_FILES)],
-            $this->getBlacklistFilterValue(),
-            $this->getVCSFilter(),
-        ];
+        if (!($isWhiteList = $filter = $this->getWhitelistFilterValue())) {
+            $filter = array_merge(
+                [Path::join($this->formAssetsDirectoryName(), AbstractPackageInstaller::BLACKLIST_ALL_FILES)],
+                $this->getBlacklistFilterValue(),
+                $this->getVCSFilter()
+            );
+        }
 
         CopyGlobFilteredFileManager::copy(
             $packagePath,
             $this->formThemeTargetPath(),
-            $this->getCombinedFilters($filtersToApply)
+            $filter,
+            (bool) $isWhiteList
         );
 
         $this->installAssets($packagePath);
@@ -106,7 +109,8 @@ class ThemePackageInstaller extends AbstractPackageInstaller
             CopyGlobFilteredFileManager::copy(
                 $source,
                 $target,
-                $this->getBlacklistFilterValue()
+                $this->getWhitelistFilterValue() ?: $this->getBlacklistFilterValue(),
+                (bool) $this->getWhitelistFilterValue()
             );
         }
     }

--- a/src/Installer/PackageInstallerTrigger.php
+++ b/src/Installer/PackageInstallerTrigger.php
@@ -55,6 +55,15 @@ class PackageInstallerTrigger extends LibraryInstaller
      */
     public function setSettings($settings)
     {
+        $hasBlackList = !empty($settings[AbstractPackageInstaller::EXTRA_PARAMETER_FILTER_BLACKLIST]);
+        $hasWhiteList = !empty($settings[AbstractPackageInstaller::EXTRA_PARAMETER_FILTER_WHITELIST]);
+        if ($hasBlackList && $hasWhiteList) {
+            throw new \InvalidArgumentException(sprintf(
+                'settings %s and %s should not be used together',
+                AbstractPackageInstaller::EXTRA_PARAMETER_FILTER_BLACKLIST,
+                AbstractPackageInstaller::EXTRA_PARAMETER_FILTER_WHITELIST
+            ));
+        }
         $this->settings = $settings;
     }
 

--- a/tests/Integration/Installer/Package/ModulePackageInstallerTest.php
+++ b/tests/Integration/Installer/Package/ModulePackageInstallerTest.php
@@ -23,7 +23,7 @@ class ModulePackageInstallerTest extends AbstractPackageInstallerTest
             $package
         );
     }
-    
+
     public function testModuleNotInstalledByDefault()
     {
         $installer = $this->getPackageInstaller('test-vendor/test-package');
@@ -317,6 +317,28 @@ class ModulePackageInstallerTest extends AbstractPackageInstallerTest
 
     public function testComplexCase()
     {
+        $this->assertComplexCase([
+            'source-directory' => 'custom-root',
+            'target-directory' => 'custom-out',
+            'blacklist-filter' => [
+                '**/*.txt',
+                '**/*.pdf',
+                'documentation/**/*.*',
+            ]
+        ]);
+
+        $this->assertComplexCase([
+            'source-directory' => 'custom-root',
+            'target-directory' => 'custom-out',
+            'whitelist-filter' => [
+                '*.php',
+                'model/*.*',
+            ]
+        ]);
+    }
+
+    private function assertComplexCase(array $settings)
+    {
         $this->setupVirtualProjectRoot('vendor/test-vendor/test-package/custom-root', [
             'metadata.php' => '<?php',
             'module.php' => '<?php',
@@ -328,15 +350,7 @@ class ModulePackageInstallerTest extends AbstractPackageInstallerTest
         ]);
 
         $installer = $this->getPackageInstaller('test-vendor/test-package', '1.0.0', [
-            'oxideshop' => [
-                'source-directory' => 'custom-root',
-                'target-directory' => 'custom-out',
-                'blacklist-filter' => [
-                    '**/*.txt',
-                    '**/*.pdf',
-                    'documentation/**/*.*',
-                ]
-            ]
+            'oxideshop' => $settings
         ]);
         $installer->install($this->getVirtualFileSystemRootPath('vendor/test-vendor/test-package'));
 

--- a/tests/Integration/Installer/Package/ShopPackageInstallerTest.php
+++ b/tests/Integration/Installer/Package/ShopPackageInstallerTest.php
@@ -146,4 +146,41 @@ class ShopPackageInstallerTest extends AbstractShopPackageInstallerTest
         $this->assertVirtualFileNotExists('source/.git/objects/ff/fftest');
         $this->assertVirtualFileNotExists('source/.gitignore');
     }
+
+    public function testWhiteListFilter()
+    {
+        $this->setupVirtualProjectRoot('vendor/test-vendor/test-package/source', [
+            'index.php' => '<?php',
+            'Class.php' => '<?php',
+            'Core/Class.php' => '<?php',
+            'Application/Model/Class.php' => '<?php',
+            'Application/Controller/Class.php' => '<?php',
+            'Application/Component/Class.php' => '<?php',
+            'config.inc.php.dist' => 'dist',
+        ]);
+
+        $installer = $this->getPackageInstaller([
+            'whitelist-filter' => ["config.inc.php.dist", "*.php"]
+        ]);
+
+        $installer->install($this->getVirtualFileSystemRootPath('vendor/test-vendor/test-package'));
+
+        $this->assertVirtualFileEquals(
+            'vendor/test-vendor/test-package/source/config.inc.php.dist',
+            'source/config.inc.php.dist'
+        );
+        $this->assertVirtualFileEquals(
+            'vendor/test-vendor/test-package/source/Class.php',
+            'source/Class.php'
+        );
+        $this->assertVirtualFileEquals(
+            'vendor/test-vendor/test-package/source/index.php',
+            'source/index.php'
+        );
+
+        $this->assertVirtualFileNotExists('source/Core/Class.php');
+        $this->assertVirtualFileNotExists('source/Application/Model/Class.php');
+        $this->assertVirtualFileNotExists('source/Application/Controller/Class.php');
+        $this->assertVirtualFileNotExists('source/Application/Component/Class.php');
+    }
 }

--- a/tests/Integration/Installer/Package/ThemePackageInstallerTest.php
+++ b/tests/Integration/Installer/Package/ThemePackageInstallerTest.php
@@ -405,6 +405,27 @@ class ThemePackageInstallerTest extends AbstractPackageInstallerTest
 
     public function testComplexCase()
     {
+        $this->assertComplexCase([
+            'assets-directory' => 'custom_assets',
+            'target-directory' => 'custom-package',
+            'blacklist-filter' => [
+                '**/*.txt',
+                '**/*.pdf',
+            ]
+        ]);
+
+        $this->assertComplexCase([
+            'assets-directory' => 'custom_assets',
+            'target-directory' => 'custom-package',
+            'whitelist-filter' => [
+                '*.php',
+                '**/*.css',
+            ]
+        ]);
+    }
+
+    public function assertComplexCase(array $settings)
+    {
         $this->setupVirtualProjectRoot('vendor/test-vendor/test-package', [
             'theme.php' => '<?php',
             'theme.txt' => 'txt',
@@ -415,14 +436,7 @@ class ThemePackageInstallerTest extends AbstractPackageInstallerTest
         ]);
 
         $installer = $this->getPackageInstaller('test-vendor/test-package', '1.0.0', [
-            'oxideshop' => [
-                'assets-directory' => 'custom_assets',
-                'target-directory' => 'custom-package',
-                'blacklist-filter' => [
-                    '**/*.txt',
-                    '**/*.pdf',
-                ]
-            ]
+            'oxideshop' => $settings
         ]);
         $installer->install($this->getVirtualFileSystemRootPath('vendor/test-vendor/test-package'));
 

--- a/tests/Unit/Utilities/CopyFileManager/CopyGlobFilteredFileManagerTest.php
+++ b/tests/Unit/Utilities/CopyFileManager/CopyGlobFilteredFileManagerTest.php
@@ -15,7 +15,7 @@ use Webmozart\PathUtil\Path;
  *
  * @covers \OxidEsales\ComposerPlugin\Utilities\CopyFileManager\CopyGlobFilteredFileManager
  * @covers \OxidEsales\ComposerPlugin\Utilities\CopyFileManager\GlobMatcher\GlobMatcher
- * @covers \OxidEsales\ComposerPlugin\Utilities\CopyFileManager\GlobMatcher\Iteration\BlacklistFilterIterator
+ * @covers \OxidEsales\ComposerPlugin\Utilities\CopyFileManager\GlobMatcher\Iteration\GlobFilterIterator
  * @covers \OxidEsales\ComposerPlugin\Utilities\CopyFileManager\GlobMatcher\Integration\AbstractGlobMatcher
  * @covers \OxidEsales\ComposerPlugin\Utilities\CopyFileManager\GlobMatcher\Integration\WebmozartGlobMatcher
  * @covers \OxidEsales\ComposerPlugin\Utilities\CopyFileManager\GlobMatcher\GlobListMatcher\GlobListMatcher
@@ -24,6 +24,11 @@ class CopyGlobFilteredFileManagerTest extends \PHPUnit\Framework\TestCase
 {
     /** @var array */
     private $filter = [];
+
+    /**
+     * @var bool
+     */
+    private $isWhiteList = false;
 
     public function testBasicFileCopyOperation()
     {
@@ -225,73 +230,116 @@ class CopyGlobFilteredFileManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertFilesNotExistInDestination(["module.php"]);
     }
 
-    public function testFilteringFileCopyOperation()
+    /**
+     * @return array
+     */
+    public function providerCopy()
     {
-        $inputFiles = [
-            "module.php"        => "PHP_1",
-            "readme.md"         => "MD_1",
-            "documentation.txt" => "TXT_1",
-            "src"               => [
-                "a.php" => "PHP_2",
-                "b.php" => "PHP_3",
-                "c.php" => "PHP_3",
+        $structure = [
+            'module.php'        => 'PHP_1',
+            'readme.md'         => 'MD_1',
+            'documentation.txt' => 'TXT_1',
+            'src'               => [
+                'a.php' => 'PHP_2',
+                'b.php' => 'PHP_3',
+                'c.php' => 'PHP_3',
             ],
-            "tests"             => [
-                "test.php"    => "PHP_4",
-                "unit"        => [
-                    "test.php" => "PHP_5",
+            'tests'             => [
+                'test.php'    => 'PHP_4',
+                'unit'        => [
+                    'test.php' => 'PHP_5',
                 ],
-                "integration" => [
-                    "test.php" => "PHP_6",
+                'integration' => [
+                    'test.php' => 'PHP_6',
                 ]
             ],
-            "documentation"     => [
-                "document_a.pdf" => "PDF_1",
-                "document_b.pdf" => "PDF_2",
-                "index.txt"      => "TXT_2",
-                "example.php"    => "PHP_7",
+            'documentation'     => [
+                'document_a.pdf' => 'PDF_1',
+                'document_b.pdf' => 'PDF_2',
+                'index.txt'      => 'TXT_2',
+                'example.php'    => 'PHP_7',
             ]
         ];
 
-        $this->prepareVirtualFileSystem($inputFiles, []);
+        return [
+            'blacklist' => [
+                [
+                    'module.php'                   => true,
+                    'src/a.php'                    => true,
+                    'src/b.php'                    => true,
+                    'src/c.php'                    => true,
+                    'documentation/example.php'    => true,
 
-        $this->setFilter(
-            [
-                "**/*.md",
-                "**/*.txt",
-                "tests/**/*.*",
-                "documentation/**/*.pdf",
-            ]
-        );
-        $this->simulateCopyWithFilter();
+                    'readme.md'                    => false,
+                    'documentation.txt'            => false,
+                    'tests/test.php'               => false,
+                    'tests/unit/test.php'          => false,
+                    'tests/integration/test.php'   => false,
+                    'documentation/document_a.pdf' => false,
+                    'documentation/document_b.pdf' => false,
+                    'documentation/index.txt'      => false,
+                ],
+                $structure,
+                [
+                    '**/*.md',
+                    '**/*.txt',
+                    'tests/**/*.*',
+                    'documentation/**/*.pdf',
+                ],
+                false,
+            ],
 
-        $this->assertFileCopyIsIdentical(
-            [
-                "module.php",
-                "src/a.php",
-                "src/b.php",
-                "src/c.php",
-                "documentation/example.php",
-            ]
-        );
+            'whitelist' => [
+                [
+                    'module.php'                   => false,
+                    'src/a.php'                    => false,
+                    'src/b.php'                    => false,
+                    'src/c.php'                    => false,
+                    'documentation/example.php'    => false,
 
-        $this->assertFilesNotExistInDestination(
-            [
-                "readme.md",
-                "documentation.txt",
-                "tests/test.php",
-                "tests/unit/test.php",
-                "tests/integration/test.php",
-                "documentation/document_a.pdf",
-                "documentation/document_b.pdf",
-                "documentation/index.txt",
-            ]
-        );
+                    'readme.md'                    => true,
+                    'documentation.txt'            => true,
+                    'tests/test.php'               => true,
+                    'tests/unit/test.php'          => true,
+                    'tests/integration/test.php'   => true,
+                    'documentation/document_a.pdf' => true,
+                    'documentation/document_b.pdf' => true,
+                    'documentation/index.txt'      => true,
+                ],
+                $structure,
+                [
+                    '**/*.md',
+                    '**/*.txt',
+                    'tests/**/*.*',
+                    'documentation/**/*.pdf',
+                ],
+                true,
+            ],
+        ];
     }
 
-    protected function setFilter($filter)
+    /**
+     * @dataProvider providerCopy
+     *
+     * @param array $expected
+     * @param array $structure
+     * @param array $filter
+     * @param bool $isWhiteList
+     */
+    public function testCopy(array $expected, array $structure, array $filter, $isWhiteList)
+    {
+        $this->setFilter($filter, $isWhiteList);
+        $this->prepareVirtualFileSystem($structure, []);
+        $this->simulateCopyWithFilter();
+        foreach ($expected as $path => $identical) {
+            $identical ? $this->assertFileCopyIsIdentical([$path]) : $this->assertFilesNotExistInDestination([$path]);
+        }
+    }
+
+    protected function setFilter($filter, $isWhiteList = false)
     {
         $this->filter = $filter;
+        $this->isWhiteList = $isWhiteList;
     }
 
     protected function prepareVirtualFileSystem($inputStructure, $outputStructure)
@@ -310,7 +358,7 @@ class CopyGlobFilteredFileManagerTest extends \PHPUnit\Framework\TestCase
         $sourcePath = $this->getSourcePath($source);
         $destinationPath = $this->getDestinationPath($destination);
 
-        CopyGlobFilteredFileManager::copy($sourcePath, $destinationPath, $this->filter);
+        CopyGlobFilteredFileManager::copy($sourcePath, $destinationPath, $this->filter, $this->isWhiteList);
     }
 
     protected function getSourcePath($suffixForSource = null)
@@ -330,20 +378,6 @@ class CopyGlobFilteredFileManagerTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    protected function assertFilesExistInDestination($paths)
-    {
-        foreach ($paths as $path) {
-            $this->assertFileExists($this->getDestinationPath($path));
-        }
-    }
-
-    protected function assertFilesNotExistInSource($paths)
-    {
-        foreach ($paths as $path) {
-            $this->assertFileNotExists($this->getSourcePath($path));
-        }
-    }
-
     protected function assertFilesNotExistInDestination($paths)
     {
         foreach ($paths as $path) {
@@ -355,13 +389,6 @@ class CopyGlobFilteredFileManagerTest extends \PHPUnit\Framework\TestCase
     {
         foreach ($paths as $path) {
             $this->assertFileEquals($this->getSourcePath($path), $this->getDestinationPath($path));
-        }
-    }
-
-    protected function assertFileCopyIsDifferent($paths)
-    {
-        foreach ($paths as $path) {
-            $this->assertFileNotEquals($this->getSourcePath($path), $this->getDestinationPath($path));
         }
     }
 }


### PR DESCRIPTION
It is usually a fixed set of files that need to be copied to the `source` folder during installation.
IMO would be a whitelist filter easier to define in most cases.
In particular, I noticed it in connection with the PR #15, since many more files had to be excluded there
(`.idea/ **/*`,  `vendor/**/*`,  `source/**/*`)

Instead of a blacklist

```json
{
  "name": "foo/bar",
  "type": "oxideshop-module",
  "require": {
    "php": ">=7.1",
    ...
  },
  "require-dev": {
    "oxid-esales/oxideshop-ce": "^6",
    ...
  },
  "extra": {
    "oxideshop": {
      "blacklist-filter": [
        ".*/**/*",
        "config/**/*",
        "source/**/*",
        "src/**/*",
        "vendor/**/*",
        ...
      ],
      "target-directory": "foo/bar"
    }
  }
}
```

offers a whitelist

```json
{
  "name": "foo/bar",
  "type": "oxideshop-module",
  "require": {
    "php": ">=7.1",
    ...
  },
  "require-dev": {
    "oxid-esales/oxideshop-ce": "^6",
    ...
  },
  "extra": {
    "oxideshop": {
      "whitelist-filter": [
        "logo.png",
        "menu.xml",
        "metadata.php",
        "out/**/*",
        "translations/**/*",
        "views/**/*"
      ],
      "target-directory": "foo/bar"
    }
  }
}
```

more stability, and does not have to be checked or adjusted with every new file or directory.