### PR TITLE
do not delete module

### DIFF
--- a/src/Installer/Package/ModulePackageInstaller.php
+++ b/src/Installer/Package/ModulePackageInstaller.php
@@ -48,6 +48,13 @@ class ModulePackageInstaller extends AbstractPackageInstaller
      */
     public function update($packagePath)
     {
+        $realPath = realpath($packagePath);
+        $targetPath = $this->formTargetPath();
+        if ($realPath == $targetPath) {
+            //do not try to install into the source directory
+            return;
+        }
+   
         $moduleInstaller = $this->getModuleInstaller();
         $package = $this->getOxidShopPackage($packagePath);
 


### PR DESCRIPTION
use case: a developer installs modules from /source/modules/abbr/modulename by configuring composer to use that path as source for package installation. For example 
```
"repositories": [
    {
      "type": "path",
      "url": "source/modules/oxps/*"
    }
  ]
```
This is used to develop project specific modules or to get started with the initial module development. 

As composer will create symlinks to the vendor folder also debugging and adapting the php source files is straight forward. 

In this case overwriting source with target by the composer plugin will destroy the module - so without this developers have to be carefully saying "no" when composer plugin asks to overwrite. with this change there are some less stupid questions when running composer update