### PR TITLE
do not overwrite modules that are already installed in the right version

### DIFF
--- a/src/Installer/Package/ModulePackageInstaller.php
+++ b/src/Installer/Package/ModulePackageInstaller.php
@@ -37,7 +37,7 @@ class ModulePackageInstaller extends AbstractPackageInstaller
     public function install($packagePath)
     {
         $this->getIO()->write("Installing module {$this->getPackageName()} package.");
-        $package = $this->getOxidShopPackage($packagePath));
+        $package = $this->getOxidShopPackage($packagePath);
         $this->installOrUpdate($package);
     }
 
@@ -47,9 +47,9 @@ class ModulePackageInstaller extends AbstractPackageInstaller
     private function installOrUpdate($package){
         $moduleInstaller = $this->getModuleInstaller();
         $moduleInstaller->install($package);
-        $installation_info = ['version'=>$this->getPackage()
+        $installationInfo = ['version'=>$this->getPackage()
             ->getVersion()];
-        $data_as_json = json_encode($installation_info);
+        $dataAsJson = json_encode($installationInfo);
         file_put_contents($this->formTargetPath() . DIRECTORY_SEPARATOR . 'installed.json', $data_as_json);
     }
 


### PR DESCRIPTION
not trying to overwrite modules if the installed version is equal to the version being installed
that will not cover all questions but may be simple to implement and avoiding a lot of useless questions.

If the module is already installed in the correct version there is no need to overwrite it.

To detect this the version must be saved during the installation to the target folder and must contain a version that identifies a specific version like v1.2.3 and not dev-master