### PR TITLE
adapt code to PSR-12 coding standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ notifications:
   email: false
 
 php:
-  - "7.0"
   - "7.1"
   - "7.2"
   - "7.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ install:
 
 script:
   - find {src,tests} -name "*.php" -print0 | xargs -0 -n1 -P8 php -l
-  - vendor/bin/phpcs --standard=PSR12 --extensions=php src
+  - vendor/bin/phpcs --standard=PSR12 --extensions=php src tests
   - vendor/bin/phpunit tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ install:
 
 script:
   - find {src,tests} -name "*.php" -print0 | xargs -0 -n1 -P8 php -l
-  - vendor/bin/phpcs --standard=PSR2 --extensions=php src
+  - vendor/bin/phpcs --standard=PSR12 --extensions=php src
   - vendor/bin/phpunit tests

--- a/src/Installer/Package/AbstractPackageInstaller.php
+++ b/src/Installer/Package/AbstractPackageInstaller.php
@@ -3,7 +3,6 @@
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
- * @phpcs:disable PSR12.Properties.ConstantVisibility.NotFound
  */
 
 declare(strict_types=1);
@@ -19,34 +18,34 @@ use Composer\Package\PackageInterface;
  */
 abstract class AbstractPackageInstaller
 {
-    const EXTRA_PARAMETER_KEY_ROOT = 'oxideshop';
+    public const EXTRA_PARAMETER_KEY_ROOT = 'oxideshop';
 
     /** Used to determine third party package internal source path. */
-    const EXTRA_PARAMETER_KEY_SOURCE = 'source-directory';
+    public const EXTRA_PARAMETER_KEY_SOURCE = 'source-directory';
 
     /** Used to install third party integrations. */
-    const EXTRA_PARAMETER_KEY_TARGET = 'target-directory';
+    public const EXTRA_PARAMETER_KEY_TARGET = 'target-directory';
 
     /** Used to install third party integration assets. */
-    const EXTRA_PARAMETER_KEY_ASSETS = 'assets-directory';
+    public const EXTRA_PARAMETER_KEY_ASSETS = 'assets-directory';
 
     /** Used to decide what the shop source directory is. */
-    const EXTRA_PARAMETER_SOURCE_PATH = 'source-path';
+    public const EXTRA_PARAMETER_SOURCE_PATH = 'source-path';
 
     /** List of glob expressions used to blacklist files being copied. */
-    const EXTRA_PARAMETER_FILTER_BLACKLIST = 'blacklist-filter';
+    public const EXTRA_PARAMETER_FILTER_BLACKLIST = 'blacklist-filter';
 
     /** Glob expression to filter all files, might be used to filter whole directory. */
-    const BLACKLIST_ALL_FILES = '**/*';
+    public const BLACKLIST_ALL_FILES = '**/*';
 
     /** Name of directory to be excluded for VCS */
-    const BLACKLIST_VCS_DIRECTORY = '.git';
+    protected const BLACKLIST_VCS_DIRECTORY = '.git';
 
     /** Name of ignore files to be excluded for VCS */
-    const BLACKLIST_VCS_IGNORE_FILE = '.gitignore';
+    protected const BLACKLIST_VCS_IGNORE_FILE = '.gitignore';
 
     /** Glob filter expression to exclude VCS files */
-    const BLACKLIST_VCS_DIRECTORY_FILTER = self::BLACKLIST_VCS_DIRECTORY
+    protected const BLACKLIST_VCS_DIRECTORY_FILTER = self::BLACKLIST_VCS_DIRECTORY
         . DIRECTORY_SEPARATOR
         . self::BLACKLIST_ALL_FILES;
 

--- a/src/Installer/Package/AbstractPackageInstaller.php
+++ b/src/Installer/Package/AbstractPackageInstaller.php
@@ -1,8 +1,12 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
+ * @phpcs:disable PSR12.Properties.ConstantVisibility.NotFound
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Installer\Package;
 

--- a/src/Installer/Package/ComponentInstaller.php
+++ b/src/Installer/Package/ComponentInstaller.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Installer\Package;
 

--- a/src/Installer/Package/ModulePackageInstaller.php
+++ b/src/Installer/Package/ModulePackageInstaller.php
@@ -3,7 +3,6 @@
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
- * @phpcs:disable PSR12.Properties.ConstantVisibility.NotFound
  */
 
 declare(strict_types=1);
@@ -23,7 +22,7 @@ use Webmozart\PathUtil\Path;
 class ModulePackageInstaller extends AbstractPackageInstaller
 {
     /** @var string MODULES_DIRECTORY */
-    const MODULES_DIRECTORY = 'modules';
+    protected const MODULES_DIRECTORY = 'modules';
 
     /**
      * @return bool

--- a/src/Installer/Package/ModulePackageInstaller.php
+++ b/src/Installer/Package/ModulePackageInstaller.php
@@ -1,8 +1,12 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
+ * @phpcs:disable PSR12.Properties.ConstantVisibility.NotFound
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Installer\Package;
 

--- a/src/Installer/Package/ShopPackageInstaller.php
+++ b/src/Installer/Package/ShopPackageInstaller.php
@@ -3,7 +3,6 @@
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
- * @phpcs:disable PSR12.Properties.ConstantVisibility.NotFound
  */
 
 declare(strict_types=1);
@@ -19,15 +18,15 @@ use Webmozart\PathUtil\Path;
  */
 class ShopPackageInstaller extends AbstractPackageInstaller
 {
-    const FILE_TO_CHECK_IF_PACKAGE_INSTALLED = 'index.php';
-    const SHOP_SOURCE_CONFIGURATION_FILE = 'config.inc.php';
-    const OFFLINE_FILE = 'offline.html';
-    const DISTRIBUTION_FILE_EXTENSION_MARK = '.dist';
-    const SHOP_SOURCE_DIRECTORY = 'source';
-    const SHOP_SOURCE_SETUP_DIRECTORY = 'Setup';
-    const HTACCESS_FILTER = '**/.htaccess';
-    const ROBOTS_EXCLUSION_FILTER = '**/robots.txt';
-    const SETUP_FILES_FILTER = self::SHOP_SOURCE_SETUP_DIRECTORY
+    public const SHOP_SOURCE_DIRECTORY = 'source';
+    protected const FILE_TO_CHECK_IF_PACKAGE_INSTALLED = 'index.php';
+    protected const SHOP_SOURCE_CONFIGURATION_FILE = 'config.inc.php';
+    protected const OFFLINE_FILE = 'offline.html';
+    protected const DISTRIBUTION_FILE_EXTENSION_MARK = '.dist';
+    protected const SHOP_SOURCE_SETUP_DIRECTORY = 'Setup';
+    protected const HTACCESS_FILTER = '**/.htaccess';
+    protected const ROBOTS_EXCLUSION_FILTER = '**/robots.txt';
+    protected const SETUP_FILES_FILTER = self::SHOP_SOURCE_SETUP_DIRECTORY
         . DIRECTORY_SEPARATOR
         . AbstractPackageInstaller::BLACKLIST_ALL_FILES;
 

--- a/src/Installer/Package/ShopPackageInstaller.php
+++ b/src/Installer/Package/ShopPackageInstaller.php
@@ -1,8 +1,12 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
+ * @phpcs:disable PSR12.Properties.ConstantVisibility.NotFound
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Installer\Package;
 

--- a/src/Installer/Package/ThemePackageInstaller.php
+++ b/src/Installer/Package/ThemePackageInstaller.php
@@ -3,7 +3,6 @@
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
- * @phpcs:disable PSR12.Properties.ConstantVisibility.NotFound
  */
 
 declare(strict_types=1);
@@ -19,8 +18,8 @@ use Webmozart\PathUtil\Path;
  */
 class ThemePackageInstaller extends AbstractPackageInstaller
 {
-    const METADATA_FILE_NAME = 'theme.php';
-    const PATH_TO_THEMES = "Application/views";
+    protected const METADATA_FILE_NAME = 'theme.php';
+    protected const PATH_TO_THEMES = "Application/views";
 
     /**
      * @return bool

--- a/src/Installer/Package/ThemePackageInstaller.php
+++ b/src/Installer/Package/ThemePackageInstaller.php
@@ -1,8 +1,12 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
+ * @phpcs:disable PSR12.Properties.ConstantVisibility.NotFound
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Installer\Package;
 
@@ -23,7 +27,7 @@ class ThemePackageInstaller extends AbstractPackageInstaller
      */
     public function isInstalled()
     {
-        return file_exists($this->formThemeTargetPath().'/'.static::METADATA_FILE_NAME);
+        return file_exists($this->formThemeTargetPath() . '/' . static::METADATA_FILE_NAME);
     }
 
     /**

--- a/src/Installer/PackageInstallerTrigger.php
+++ b/src/Installer/PackageInstallerTrigger.php
@@ -1,8 +1,12 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
+ * @phpcs:disable PSR12.Properties.ConstantVisibility.NotFound
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Installer;
 

--- a/src/Installer/PackageInstallerTrigger.php
+++ b/src/Installer/PackageInstallerTrigger.php
@@ -3,7 +3,6 @@
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
- * @phpcs:disable PSR12.Properties.ConstantVisibility.NotFound
  */
 
 declare(strict_types=1);
@@ -24,11 +23,11 @@ use Webmozart\PathUtil\Path;
  */
 class PackageInstallerTrigger extends LibraryInstaller
 {
-    const TYPE_ESHOP = 'oxideshop';
-    const TYPE_MODULE = 'oxideshop-module';
-    const TYPE_THEME = 'oxideshop-theme';
-    const TYPE_DEMODATA = 'oxideshop-demodata';
-    const TYPE_COMPONENT = 'oxideshop-component';
+    protected const TYPE_ESHOP = 'oxideshop';
+    protected const TYPE_MODULE = 'oxideshop-module';
+    protected const TYPE_THEME = 'oxideshop-theme';
+    protected const TYPE_DEMODATA = 'oxideshop-demodata';
+    protected const TYPE_COMPONENT = 'oxideshop-component';
 
     /** @var array Available installers for packages. */
     private $installers = [

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,8 +1,12 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
+ * @phpcs:disable PSR12.Properties.ConstantVisibility.NotFound
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin;
 
@@ -124,7 +128,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     private function bootstrapOxidShopComponent()
     {
         if ($this->isShopLaunched()) {
-            $bootstrapFilePath = (new Facts())->getSourcePath() . DIRECTORY_SEPARATOR. 'bootstrap.php';
+            $bootstrapFilePath = (new Facts())->getSourcePath() . DIRECTORY_SEPARATOR . 'bootstrap.php';
             require_once $bootstrapFilePath;
         }
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -3,7 +3,6 @@
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
- * @phpcs:disable PSR12.Properties.ConstantVisibility.NotFound
  */
 
 declare(strict_types=1);
@@ -27,9 +26,9 @@ use OxidEsales\Facts\Facts;
  */
 class Plugin implements PluginInterface, EventSubscriberInterface
 {
-    const ACTION_INSTALL = 'install';
+    protected const ACTION_INSTALL = 'install';
 
-    const ACTION_UPDATE = 'update';
+    protected const ACTION_UPDATE = 'update';
 
     /** @var Composer */
     private $composer;

--- a/src/Utilities/CopyFileManager/CopyGlobFilteredFileManager.php
+++ b/src/Utilities/CopyFileManager/CopyGlobFilteredFileManager.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Utilities\CopyFileManager;
 
@@ -33,14 +36,14 @@ class CopyGlobFilteredFileManager
     public static function copy($sourcePath, $destinationPath, $globExpressionList = [])
     {
         if (!is_string($sourcePath)) {
-            $message = "Given value \"$sourcePath\" is not a valid source path entry. ".
+            $message = "Given value \"$sourcePath\" is not a valid source path entry. " .
                 "Valid entry must be an absolute path to an existing file or directory.";
 
             throw new \InvalidArgumentException($message);
         }
 
         if (!is_string($destinationPath)) {
-            $message = "Given value \"$destinationPath\" is not a valid destination path entry. ".
+            $message = "Given value \"$destinationPath\" is not a valid destination path entry. " .
                 "Valid entry must be an absolute path to an existing directory.";
 
             throw new \InvalidArgumentException($message);

--- a/src/Utilities/CopyFileManager/GlobMatcher/GlobListMatcher/GlobListMatcher.php
+++ b/src/Utilities/CopyFileManager/GlobMatcher/GlobListMatcher/GlobListMatcher.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Utilities\CopyFileManager\GlobMatcher\GlobListMatcher;
 
@@ -40,9 +43,11 @@ class GlobListMatcher
      */
     public function matchAny($relativePath, $globExpressionList)
     {
-        if (!is_array($globExpressionList) && (!$globExpressionList instanceof \Traversable)
-            && (!is_null($globExpressionList))) {
-            $message = "Given value \"$globExpressionList\" is not a valid glob expression list. ".
+        if (
+            !is_array($globExpressionList) && (!$globExpressionList instanceof \Traversable)
+            && (!is_null($globExpressionList))
+        ) {
+            $message = "Given value \"$globExpressionList\" is not a valid glob expression list. " .
                 "Valid entry must be a list of glob expressions e.g. [\"*.txt\", \"*.pdf\"].";
 
             throw new \InvalidArgumentException($message);

--- a/src/Utilities/CopyFileManager/GlobMatcher/GlobMatcher.php
+++ b/src/Utilities/CopyFileManager/GlobMatcher/GlobMatcher.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Utilities\CopyFileManager\GlobMatcher;
 

--- a/src/Utilities/CopyFileManager/GlobMatcher/Integration/AbstractGlobMatcher.php
+++ b/src/Utilities/CopyFileManager/GlobMatcher/Integration/AbstractGlobMatcher.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Utilities\CopyFileManager\GlobMatcher\Integration;
 
@@ -30,14 +33,14 @@ abstract class AbstractGlobMatcher
     public function match($relativePath, $globExpression)
     {
         if (!is_string($globExpression) && !is_null($globExpression)) {
-            $message = "Given value \"$globExpression\" is not a valid glob expression. ".
+            $message = "Given value \"$globExpression\" is not a valid glob expression. " .
                 "Valid expression must be a string e.g. \"*.txt\".";
 
             throw new InvalidArgumentException($message);
         }
 
         if (Path::isAbsolute((string)$globExpression)) {
-            $message = "Given value \"$globExpression\" is an absolute path. ".
+            $message = "Given value \"$globExpression\" is an absolute path. " .
                 "Glob expression can only be accepted if it's a relative path.";
 
             throw new InvalidArgumentException($message);

--- a/src/Utilities/CopyFileManager/GlobMatcher/Integration/WebmozartGlobMatcher.php
+++ b/src/Utilities/CopyFileManager/GlobMatcher/Integration/WebmozartGlobMatcher.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Utilities\CopyFileManager\GlobMatcher\Integration;
 

--- a/src/Utilities/CopyFileManager/GlobMatcher/Iteration/BlacklistFilterIterator.php
+++ b/src/Utilities/CopyFileManager/GlobMatcher/Iteration/BlacklistFilterIterator.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * This file is part of OXID eShop Composer plugin.
  *
@@ -19,6 +20,8 @@
  * @copyright (C) OXID eSales AG 2003-2017
  * @version   OXID eShop Composer plugin
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Utilities\CopyFileManager\GlobMatcher\Iteration;
 

--- a/src/Utilities/VfsFileStructureOperator.php
+++ b/src/Utilities/VfsFileStructureOperator.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Utilities;
 

--- a/tests/Integration/Installer/Package/AbstractPackageInstallerTest.php
+++ b/tests/Integration/Installer/Package/AbstractPackageInstallerTest.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Tests\Integration\Installer\Package;
 

--- a/tests/Integration/Installer/Package/AbstractShopPackageInstallerTest.php
+++ b/tests/Integration/Installer/Package/AbstractShopPackageInstallerTest.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Tests\Integration\Installer\Package;
 

--- a/tests/Integration/Installer/Package/ShopPackageInstallerHtaccessFilesTest.php
+++ b/tests/Integration/Installer/Package/ShopPackageInstallerHtaccessFilesTest.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Tests\Integration\Installer\Package;
 

--- a/tests/Integration/Installer/Package/ShopPackageInstallerRobotsExclusionFilesTest.php
+++ b/tests/Integration/Installer/Package/ShopPackageInstallerRobotsExclusionFilesTest.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Tests\Integration\Installer\Package;
 

--- a/tests/Integration/Installer/Package/ShopPackageInstallerSetupFilesTest.php
+++ b/tests/Integration/Installer/Package/ShopPackageInstallerSetupFilesTest.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Tests\Integration\Installer\Package;
 

--- a/tests/Integration/Installer/Package/ShopPackageInstallerTest.php
+++ b/tests/Integration/Installer/Package/ShopPackageInstallerTest.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Tests\Integration\Installer\Package;
 

--- a/tests/Integration/Installer/Package/ThemePackageInstallerTest.php
+++ b/tests/Integration/Installer/Package/ThemePackageInstallerTest.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Tests\Integration\Installer\Package;
 

--- a/tests/Integration/Installer/PackageInstallerTriggerTest.php
+++ b/tests/Integration/Installer/PackageInstallerTriggerTest.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Tests\Integration\Installer;
 

--- a/tests/Unit/Utilities/CopyFileManager/CopyGlobFilteredFileManagerTest.php
+++ b/tests/Unit/Utilities/CopyFileManager/CopyGlobFilteredFileManagerTest.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Tests\Unit\Utilities\CopyFileManager;
 

--- a/tests/Unit/Utilities/VfsFileStructureOperatorTest.php
+++ b/tests/Unit/Utilities/VfsFileStructureOperatorTest.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 namespace OxidEsales\ComposerPlugin\Tests\Unit\Utilities;
 
@@ -42,7 +45,10 @@ class VfsFileStructureOperatorTest extends \PHPUnit\Framework\TestCase
 
     public function testReturnArrayAsIsWhenMultipleItemsArePresent()
     {
-        $this->assertSame(['foo' => 'abc', 'bar' => 'def'], VfsFileStructureOperator::nest(['foo' => 'abc', 'bar' => 'def']));
+        $this->assertSame(
+            ['foo' => 'abc', 'bar' => 'def'],
+            VfsFileStructureOperator::nest(['foo' => 'abc', 'bar' => 'def'])
+        );
     }
 
     public function testReturnArrayAsIsWhenOnlyOneFileIsPresent()
@@ -156,7 +162,7 @@ class VfsFileStructureOperatorTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expectedOutput, VfsFileStructureOperator::nest($input));
     }
 
-    public function testReturnNestedArrayWhenMultipleItemsContainsMultiLevelPathWithSameBaseButWithBreakPointInTheMiddle()
+    public function testReturnNestedArrayWhenMultipleItemsContainsMultiLevelPathWithSameBaseButWithBreakPointInside()
     {
         $input = [
             'directory/file'        => 'contents',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,10 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * Copyright © OXID eSales AG. All rights reserved.
  * See LICENSE file for license details.
  */
+
+declare(strict_types=1);
 
 require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
I've adapted the codestyle to PSR-12:
* added visibility to all class constants
* moved `declare(strict_types=1);` after file-docblock
* renamed a long method:
```
old: testReturnNestedArrayWhenMultipleItemsContainsMultiLevelPathWithSameBaseButWithBreakPointInTheMiddle
new: testReturnNestedArrayWhenMultipleItemsContainsMultiLevelPathWithSameBaseButWithBreakPointInside
```
* some minor fixes