### PR TITLE
Avoid overwriting favicon.ico when installing package.

### DIFF
--- a/src/Installer/Package/ShopPackageInstaller.php
+++ b/src/Installer/Package/ShopPackageInstaller.php
@@ -22,6 +22,7 @@ class ShopPackageInstaller extends AbstractPackageInstaller
     public const SHOP_SOURCE_DIRECTORY = 'source';
     public const FILE_TO_CHECK_IF_PACKAGE_INSTALLED = 'index.php';
     public const SHOP_SOURCE_CONFIGURATION_FILE = 'config.inc.php';
+    public const FAVICON_FILE = 'favicon.ico';
     public const OFFLINE_FILE = 'offline.html';
     public const DISTRIBUTION_FILE_EXTENSION_MARK = '.dist';
     public const SHOP_SOURCE_SETUP_DIRECTORY = 'Setup';
@@ -92,6 +93,7 @@ class ShopPackageInstaller extends AbstractPackageInstaller
         $this->copySetupFiles($packagePath);
         $this->copyConfigurationDistFileWithinTarget();
         $this->copyHtaccessFiles($packagePath);
+        $this->copyFaviconFile($packagePath);
         $this->copyOfflineFile($packagePath);
         $this->copyRobotsExclusionFiles($packagePath);
     }
@@ -108,6 +110,7 @@ class ShopPackageInstaller extends AbstractPackageInstaller
             [self::HTACCESS_FILTER],
             [self::ROBOTS_EXCLUSION_FILTER],
             [self::SETUP_FILES_FILTER],
+            [self::FAVICON_FILE],
             [self::OFFLINE_FILE],
             $this->getVCSFilter(),
         ];
@@ -140,6 +143,19 @@ class ShopPackageInstaller extends AbstractPackageInstaller
         $this->copyFilesFromSourceToInstallationByFilter(
             $packagePath,
             self::HTACCESS_FILTER
+        );
+    }
+
+    /**
+     * Copy shop's favicon from package.
+     *
+     * @param string $packagePath Absolute path which points to shop's package directory.
+     */
+    private function copyFaviconFile($packagePath)
+    {
+        $this->copyFilesFromSourceToInstallationByFilter(
+            $packagePath,
+            self::FAVICON_FILE
         );
     }
 

--- a/src/Installer/Package/ShopPackageInstaller.php
+++ b/src/Installer/Package/ShopPackageInstaller.php
@@ -144,7 +144,7 @@ class ShopPackageInstaller extends AbstractPackageInstaller
     }
 
     /**
-     * Copy shop's offline/maintenange page from package.
+     * Copy shop's offline/maintenance page from package.
      *
      * @param string $packagePath Absolute path which points to shop's package directory.
      */


### PR DESCRIPTION
This covers a similar case to #17 except this time it affects favicon.ico which many shops tend to customize. As such I just did the same thing with the code as in the other pull request.

The effect is that favicon.ico is only written if it does not exist.
