### PR TITLE
allow composer v2 and added travis php7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - "7.1"
   - "7.2"
   - "7.3"
-
+  - "7.4"
 install:
   - composer install
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "prefer-stable": true,
   "require": {
     "php": "^7.0",
-    "composer-plugin-api": "^1.0",
+    "composer-plugin-api": "^1.0|^2.0",
     "symfony/filesystem": "^3.0",
     "webmozart/glob": "^4.1",
     "webmozart/path-util": "^2.3"


### PR DESCRIPTION
Allow composer v2.
PHP 7.4 is also a valid requirement therefor it was added to travis.

Not sure if the Plugin needs furtheradjustments for composer-plugin-api v2 but this PR should start the discussion. 
https://php.watch/articles/composer-2#plugin-api-2

Would be great if this could be added to OXID 6.2.*