### PR TITLE
Added configuration for `update-ask-true` and `update-ask-false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [5.2.3] - Unreleased
+## [Unreleased]
+
+### Added
+
+- A way to configure extra parameters to answer the update overwrite question. Useful if you have symlinks
+
+In your composer.json file you can add the following.
+
+> [!NOTE]  
+> **update-ask-true** will answer Y for the `composer update` prompts
+> **update-ask-false** will answer N for the `composer update` prompts
+
+```json
+  "extra": {
+    "oxideshop": {
+      "update-ask-true": [
+        "oxid-esales/oxideshop-ce",
+        "ddoe/wysiwyg-editor-module",
+        "oxid-esales/wave-theme",
+        "ecs/fixsmartyincontent"
+      ],
+      "update-ask-false": [
+        "ecs/adminrights",
+        "ecs/ustidcheck"
+      ]
+    }
+  }
+```
 
 ### Fixed
 - Install/update logic disregards package dependency weight

--- a/README.md
+++ b/README.md
@@ -16,6 +16,34 @@ Available types are:
 - oxideshop-module - Modules, which are installed into source directory. Modules depends on main shop package.
 - oxideshop-theme - Themes, which are installed into source directory. Themes depends on main shop package.
 
+Configuration
+-------------
+
+In your composer.json file you can add the following to help you with the `composer update` prompts. This is useful
+for symlinks on installs or possibly other reasons. The packages name in composer is the name you would enter into the 
+composer.json file.
+
+> [!NOTE]  
+> **update-ask-true** will answer Y for the `composer update` prompts
+> **update-ask-false** will answer N for the `composer update` prompts
+
+```json
+  "extra": {
+    "oxideshop": {
+      "update-ask-true": [
+        "oxid-esales/oxideshop-ce",
+        "ddoe/wysiwyg-editor-module",
+        "oxid-esales/wave-theme",
+        "ecs/fixsmartyincontent"
+      ],
+      "update-ask-false": [
+        "ecs/adminrights",
+        "ecs/ustidcheck"
+      ]
+    }
+  }
+```
+
 Bugs and Issues
 ---------------
 

--- a/src/Installer/Package/AbstractPackageInstaller.php
+++ b/src/Installer/Package/AbstractPackageInstaller.php
@@ -58,6 +58,9 @@ abstract class AbstractPackageInstaller
     /** @var PackageInterface */
     private $package;
 
+    /** @var array  */
+    private $settings = [];
+
     /**
      * AbstractInstaller constructor.
      *
@@ -65,12 +68,27 @@ abstract class AbstractPackageInstaller
      * @param string           $rootDirectory
      * @param PackageInterface $package
      */
-    public function __construct(IOInterface $io, $rootDirectory, PackageInterface $package)
+    public function __construct(IOInterface $io, $rootDirectory, PackageInterface $package, $settings)
     {
         $this->io = $io;
         $this->rootDirectory = $rootDirectory;
         $this->package = $package;
+        $this->settings = $settings;
     }
+
+
+    /**
+     * Check if the package has a preference to the update y/n question
+     *
+     * @param $packageName
+     * @param $preferenceCheck
+     * @return bool
+     */
+    public function isPreferenceUpdate($packageName, $preferenceCheck = 'true')
+    {
+        return in_array($packageName, $this->settings['update-ask-' . $preferenceCheck]);
+    }
+
 
     /**
      * Run package installation procedure. After installation files should be moved to correct location.
@@ -198,9 +216,14 @@ abstract class AbstractPackageInstaller
      */
     protected function askQuestion($messageToAsk)
     {
-        $userInput = $this->getIO()->ask($messageToAsk, 'N');
-
-        return $this->isPositiveUserInput($userInput);
+        if ($this->isPreferenceUpdate($this->getPackageName(), 'false')) {
+            return false;
+        } elseif ($this->isPreferenceUpdate($this->getPackageName(), 'true')) {
+            return true;
+        } else {
+            $userInput = $this->getIO()->ask($messageToAsk, 'N');
+            return $this->isPositiveUserInput($userInput);
+        }
     }
 
     /**

--- a/src/Installer/PackageInstallerTrigger.php
+++ b/src/Installer/PackageInstallerTrigger.php
@@ -114,6 +114,6 @@ class PackageInstallerTrigger extends LibraryInstaller
      */
     protected function createInstaller(PackageInterface $package)
     {
-        return new $this->installers[$package->getType()]($this->io, $this->getShopSourcePath(), $package);
+        return new $this->installers[$package->getType()]($this->io, $this->getShopSourcePath(), $package, $this->settings);
     }
 }


### PR DESCRIPTION
In your composer.json file you can add the following to help you with the `composer update` prompts. This is useful for symlinks on installs or possibly other reasons. The packages name in composer is the name you would enter into the composer.json file.

> [!NOTE]  
> **update-ask-true** will answer Y for the `composer update` prompts
> **update-ask-false** will answer N for the `composer update` prompts

```json
  "extra": {
    "oxideshop": {
      "update-ask-true": [
        "oxid-esales/oxideshop-ce",
        "ddoe/wysiwyg-editor-module",
        "oxid-esales/wave-theme",
        "ecs/fixsmartyincontent"
      ],
      "update-ask-false": [
        "ecs/adminrights",
        "ecs/ustidcheck"
      ]
    }
  }
```